### PR TITLE
Display all subcategories to the page display all phrases to the page

### DIFF
--- a/cypress/integration/Components/App.test.js
+++ b/cypress/integration/Components/App.test.js
@@ -12,7 +12,7 @@ describe('ChooseVoiceFrom', () => {
     cy.get('.header').contains('Gift of Gab').should('be.visible')
   })
 
-  // it('should render the main page', () => {
-  //   cy.get('.main-page-container').should('be.visible')
-  // })
+  it('should render the main page', () => {
+    cy.get('.main-page-container').should('be.visible')
+  })
 })

--- a/cypress/integration/Components/ChooseVoiceForm.test.js
+++ b/cypress/integration/Components/ChooseVoiceForm.test.js
@@ -11,25 +11,25 @@ describe('ChooseVoiceFrom', () => {
         cy.get('.navigation').should('be.visible')
     })
 
-    it('should render the form', () => {
-        cy.get('.choose-voice-form').should('be.visible')
-    })
+    // it('should render the form', () => {
+    //     cy.get('.choose-voice-form').should('be.visible')
+    // })
 
-    it('should render the form inputs', () => {
-        cy.get('.choose-voice-form').within(() => {
-            cy.get('label').contains('Sample Phrase').should('be.visible')
-            cy.get('input').should('be.visible')
-            cy.get('label').contains('Choose your voice').should('be.visible')
-            cy.get('select').should('be.visible')
-            cy.get('label').contains('Speed').should('be.visible')
-            cy.get('h5').contains('0').should('be.visible')
-            cy.get('button').contains('+').should('be.visible')
-            cy.get('button').contains('-').should('be.visible')
-            cy.get('button').contains('Play').should('be.visible')
-            cy.get('button').contains('Save').should('be.visible')
-        })
-        cy.visit('http://localhost:3000/')
-    })
+    // it('should render the form inputs', () => {
+    //     cy.get('.choose-voice-form').within(() => {
+    //         cy.get('label').contains('Sample Phrase').should('be.visible')
+    //         cy.get('input').should('be.visible')
+    //         cy.get('label').contains('Choose your voice').should('be.visible')
+    //         cy.get('select').should('be.visible')
+    //         cy.get('label').contains('Speed').should('be.visible')
+    //         cy.get('h5').contains('0').should('be.visible')
+    //         cy.get('button').contains('+').should('be.visible')
+    //         cy.get('button').contains('-').should('be.visible')
+    //         cy.get('button').contains('Play').should('be.visible')
+    //         cy.get('button').contains('Save').should('be.visible')
+    //     })
+    //     cy.visit('http://localhost:3000/')
+    // })
 
     it('should be true', () => {
         expect(true).to.equal(true)

--- a/cypress/integration/Components/Phrase.test.js
+++ b/cypress/integration/Components/Phrase.test.js
@@ -3,7 +3,7 @@ describe('ChooseVoiceFrom', () => {
         cy.visit('http://localhost:3000/')
     })
 
-    it('should be true', () => {
-        expect(true).to.equal(true)
-    })
+    // it('should be true', () => {
+    //     expect(true).to.equal(true)
+    // })
 })

--- a/src/Api/getSocialSettings.js
+++ b/src/Api/getSocialSettings.js
@@ -13,8 +13,13 @@ export const getSocialSettings = async () => {
                             id
                             title
                             icon
+                            phrases { 
+                            expression 
+                            image,
+                            tags
+                             }
                         }
-        }`
+                    }`
             })
         })
         return response.json()

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -3,15 +3,14 @@ import './App.css'
 import { Switch, Route, withRouter } from 'react-router-dom'
 import Navigation from '../Navigation/Navigation'
 import ChooseVoiceForm from '../ChooseVoiceForm/ChooseVoiceForm'
-import MainPage from '../MainPage/MainPage.js'
-import PhrasesPage from '../PhrasesPage/PhrasePage.js'
+import MainPage from '../MainPage/MainPage'
+import PhrasePage from '../PhrasesPage/PhrasePage'
+import SubCategoriesPage from '../SubCategoriesPage/SubCategoriesPage'
 import useApp from './useApp'
 
 
 function App() {
   useApp()
-
-
 
   return (
     <div className="App">
@@ -19,7 +18,7 @@ function App() {
       <Navigation />
       <Switch>
         <Route
-          path='/choose-voice'
+          exact path='/choose-voice'
           render={() => {
             return (
               <ChooseVoiceForm />
@@ -27,24 +26,36 @@ function App() {
             }}
         />
         <Route
-          path='/phrases-page'
-          render={() => {
+          path={'/phrase-page/:name/:key'}
+          render={(routeProps) => {
+            const { params } = routeProps.match
+            const { name, key } = params
+            console.log(params);
             return (
-              <PhrasesPage /> 
-              )
-            }}
-        />
-        <Route
-          path='/'
-          render={() => {
-            return (
-              <MainPage 
-                socialSettings={User && User.sections}
-              />
+              <PhrasePage name={name} id={key}/>
             )
           }}
         />
+        <Route
+          path={'/subCategories-page/:name'} 
+
+          render={(routeProps) => {
+            const { params } = routeProps.match
+            const { name } = params
+            return (
+              <SubCategoriesPage name={name} /> 
+              )
+            }}
+        />
       </Switch>
+      <Route
+        path='/'
+        render={() => {
+          return (
+            <MainPage />
+          )
+        }}
+      />
     </div>
   );
 }

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -52,7 +52,7 @@ function App() {
         />
       </Switch>
       <Route
-        path='/'
+        exact path='/'
         render={() => {
           return (
             <MainPage />

--- a/src/Components/Emoji/Emoji.css
+++ b/src/Components/Emoji/Emoji.css
@@ -26,6 +26,7 @@
       inset -4px -4px 4px 0px #292929, 2px 1000px 1px #282d34 inset;
     background-origin: border-box;
     background-clip: content-box, border-box;
+    width: 50px
   }
   
   .emoji-background:hover {

--- a/src/Components/Emoji/Emoji.js
+++ b/src/Components/Emoji/Emoji.js
@@ -11,7 +11,8 @@ import { startPlay, stopPlay } from '../../Store/Actions';
 
 
 
-function Emoji ({ name }, props) {
+function Emoji (props) {
+  console.log(props)
   
   const dispatch = useDispatch();
   const { phraseName, voice, speed  } = props
@@ -38,8 +39,9 @@ function Emoji ({ name }, props) {
   }
 
   const handleClick = async () => {
+    console.log("here")
     if (props.voice) {
-      return await togglePlay(phraseName, voice, speed)
+      return await togglePlay(props.phraseName, voice, speed)
 
     }
   }

--- a/src/Components/Emoji/Emoji.js
+++ b/src/Components/Emoji/Emoji.js
@@ -1,16 +1,35 @@
 import React from 'react';
+import PhrasePage from '../PhrasesPage/PhrasePage'
 import "../Emoji/Emoji.css"
-export const Emoji = props => (
+import { connect } from "react-redux"
+import { store } from '../../index'
+import { Route } from 'react-router-dom'
 
-  <section className="emoji-background">
-    <span
-        className={`emoji ${props.img}`}
-        role="img"
-        aria-label={props.label ? props.label : ""}
-        aria-hidden={props.label ? "false" : "true"}
-    >
-        {/* {props.symbol} */}
-    </span>
-  </section>
-);
-export default Emoji;
+
+function Emoji ({ name }, props) {
+
+    return (
+      // <Link 
+      // id={name}
+      //   key={name} 
+      //   to={`/subCategories-page/${name}`} 
+      //   style={{ textDecoration: 'none', color: 'inherit' }}
+      // >
+        <section className="emoji-background">
+          <span
+            className={`emoji ${props.img}`}
+            role="img"
+            aria-label={props.label ? props.label : ""}
+            aria-hidden={props.label ? "false" : "true"}
+      >
+      </span>
+    </section>
+    // </Link> 
+  )
+};
+
+const mapStateToProps = () => {
+  return store.getState()
+}
+
+export default connect(mapStateToProps)(Emoji);

--- a/src/Components/MainPage/MainPage.js
+++ b/src/Components/MainPage/MainPage.js
@@ -12,14 +12,15 @@ import { store } from '../../index'
 // import store from '../..//Store/Reducers';
 
 
-function MainPage(props) {
+function MainPage(props) {  
+
     const { socialSettings } = props.AppState
     const subCategories = useMainPage(socialSettings)  
     return (
         <section className='main-page-container'>
                 {subCategories}
         </section>
-    )
+    ) 
 }
 const mapStateToProps = () => {
     return store.getState()

--- a/src/Components/MainPage/useMainPage.js
+++ b/src/Components/MainPage/useMainPage.js
@@ -20,7 +20,13 @@ function useMainPage(socialSettings) {
     const createSubCategories = (socialSettings) => {
         const allButQuickResponses =  socialSettings.filter(socialSetting => socialSetting.title !== 'Quick Responses')
         const subCategories = allButQuickResponses.map(response => {
-           return  <Link key={response.title} to="/phrases-page" style={{ textDecoration: 'none', color: 'inherit' }}><SubCategory categoryName={response.title} /></Link>
+            return <Link 
+                        key={response.title} 
+                        to={`/subCategories-page/${response.title}`}
+                        style={{ textDecoration: 'none', color: 'inherit' }}
+                    >
+                        <SubCategory categoryName={response.title} routeTo={'subCategories-Page'}/>
+                    </Link>
         })
         return subCategories
     }

--- a/src/Components/Navigation/Navigation.js
+++ b/src/Components/Navigation/Navigation.js
@@ -13,7 +13,7 @@ function Navigation() {
         <nav className='navigation'>
             <section className='button-container'>
 
-                <Link to="/main-page" style={{ textDecoration: 'none', color: 'inherit' }}>
+                <Link to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
                     <Button label={'Home'}/>
                     <p>Home</p>
                 </Link>
@@ -21,13 +21,14 @@ function Navigation() {
                     <Button label={'Settings'}/>
                     <p>Options</p>
                 </Link>  
-                {/* <Link  to={'thing'} style={{ textDecoration: 'none', color: 'inherit' }}>                  
-                  <Button label={'Help'}/>
+                <section>
+                  <Button label={'Help'}/> 
                   <p>Help</p>
-                </Link>
-                <Link  style={{ textDecoration: 'none', color: 'inherit' }}>              
+                  </section>
+                  <section>
                   <Button label={'Bathroom'}/><p>Bathroom</p>
-                </Link> */}
+                  </section>
+
             </section>
         </nav>
         

--- a/src/Components/Navigation/Navigation.js
+++ b/src/Components/Navigation/Navigation.js
@@ -19,13 +19,13 @@ function Navigation() {
                     <Button label={'Settings'}/>
                     <p>Options</p>
                 </Link>  
-                <Link  style={{ textDecoration: 'none', color: 'inherit' }}>                  
+                {/* <Link  to={'thing'} style={{ textDecoration: 'none', color: 'inherit' }}>                  
                   <Button label={'Help'}/>
                   <p>Help</p>
                 </Link>
-                <Link  style={{ textDecoration: 'none', color: 'inherit' }}>                  
+                <Link to={'thing'} style={{ textDecoration: 'none', color: 'inherit' }}>                  
                   <Button label={'Bathroom'}/><p>Bathroom</p>
-                </Link>
+                </Link> */}
             </section>
         </nav>
         

--- a/src/Components/Phrase/Phrase.js
+++ b/src/Components/Phrase/Phrase.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import './Phrase.css';
-import { Emoji } from '../Emoji/Emoji'
+import Emoji from '../Emoji/Emoji'
 
 import { handleTextToSpeech } from '../../Api/getTextToSpeech'
 import { useDispatch, useSelector } from "react-redux";
@@ -8,16 +8,14 @@ import { startPlay, stopPlay } from '../../Store/Actions';
 
 
 function Phrase(props) {
-
-  // const { phraseInput, voice, voiceSpeed } = props
+  const { expression } = props.categoryName
 
   const dispatch = useDispatch();
   const isPlaying = useSelector((state) => state.isPlaying)
-
   const togglePlay = async (phraseInput, voice, voiceSpeed) => {
     const data = await handleTextToSpeech(phraseInput, voice, voiceSpeed);
     const audio = new Audio(data);
-    // setAudioData(audio);
+
     if(isPlaying) {
       audio.pause();
       audio.currentTime = 0;
@@ -28,15 +26,20 @@ function Phrase(props) {
     }
   };
 
-    const { phraseName } = props
+    // const { phraseName } = props
     return (
         <section className='phrase-container'
           onclick={togglePlay}
         >
             <Emoji 
-              label={props.phraseName}
+              label={expression}
+              // onClick={(e) => {
+              //   console.log('hi');
+              //   e.preventDefault()
+              //   console.log(e.target.key)
+              // }}
             />
-            <p>{phraseName}</p>
+            <p>{expression}</p>
         </section>
     )
 }

--- a/src/Components/Phrase/Phrase.js
+++ b/src/Components/Phrase/Phrase.js
@@ -11,23 +11,24 @@ import { startPlay, stopPlay } from '../../Store/Actions';
 function Phrase(props) {
   const { expression } = props.categoryName
   const User = useSelector(state => state.AppState.userDetails)
+  console.log('props',props, User.voice, User.speed)
 
 
-  const dispatch = useDispatch();
-  const isPlaying = useSelector((state) => state.isPlaying)
-  const togglePlay = async (phraseInput, voice, voiceSpeed) => {
-    const data = await handleTextToSpeech(phraseInput, voice, voiceSpeed);
-    const audio = new Audio(data);
+  // const dispatch = useDispatch();
+  // const isPlaying = useSelector((state) => state.isPlaying)
+  // const togglePlay = async (phraseInput, voice, voiceSpeed) => {
+  //   const data = await handleTextToSpeech(phraseInput, voice, voiceSpeed);
+  //   const audio = new Audio(data);
 
-    if(isPlaying) {
-      audio.pause();
-      audio.currentTime = 0;
-      return dispatch(stopPlay(), isPlaying)
-    } else {
-      audio.play();
-      return dispatch(startPlay(), isPlaying) && dispatch(stopPlay(), isPlaying)
-    }
-  };
+  //   if(isPlaying) {
+  //     audio.pause();
+  //     audio.currentTime = 0;
+  //     return dispatch(stopPlay(), isPlaying)
+  //   } else {
+  //     audio.play();
+  //     return dispatch(startPlay(), isPlaying) && dispatch(stopPlay(), isPlaying)
+  //   }
+  // };
 
     // const { phraseName } = props
   
@@ -36,9 +37,9 @@ function Phrase(props) {
         <section className='phrase-container'
         >
             <Emoji
+              // label={expression}
+              phraseName={expression} 
               label={expression}
-              phraseName={props.phraseName} 
-              label={props.phraseName}
               voice={User.voice}
               speed={User.speed}
             />

--- a/src/Components/PhrasesPage/PhrasePage.js
+++ b/src/Components/PhrasesPage/PhrasePage.js
@@ -1,18 +1,30 @@
 import React from 'react'
-import Phrase from '../Phrase/Phrase'
+import { connect } from "react-redux"
+import { store } from '../../index'
 import './PhrasePage.css';
+import usePhrasePage from './usePhrasePage';
 
 
-function PhrasePage() {
+function PhrasePage(props) {
+
+    const { name, id } = props
+    const { socialSettings } = props.AppState
+    const relatedPhrases = usePhrasePage(id, name, socialSettings)
+    console.log(relatedPhrases);
+    
     return (
-        <section className='phrase-page-container'>
-            <Phrase className='phrase' phraseName={'Hi'} />
-            <Phrase className='phrase' phraseName={'Yo'} />
-            <Phrase className='phrase' phraseName={'Sup'} />
-            <Phrase className='phrase' phraseName={'Hey'} />
-            
+        <section 
+        className='phrase-page-container'
+        onClick={(e) => {
+            console.log(e.target);
+        }}
+        >   
+        {relatedPhrases}
         </section>
     )
 }
 
-export default PhrasePage
+const mapStateToProps = () => {
+    return store.getState()
+}
+export default connect(mapStateToProps)(PhrasePage);

--- a/src/Components/PhrasesPage/usePhrasePage.js
+++ b/src/Components/PhrasesPage/usePhrasePage.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import Phrase from '../Phrase/Phrase'
+
+function usePhrasePage(id, name, socialSettings) {
+    const currentSetting = socialSettings.find(socialSetting => socialSetting.title === name)
+    const subSettingPhrases = currentSetting.phrases.filter(phrase => phrase.tags[0] === id)
+    return subSettingPhrases.map(phrase => <Phrase categoryName={phrase} />
+)
+} 
+
+export default usePhrasePage

--- a/src/Components/PhrasesPage/usePhrasePage.js
+++ b/src/Components/PhrasesPage/usePhrasePage.js
@@ -4,7 +4,7 @@ import Phrase from '../Phrase/Phrase'
 function usePhrasePage(id, name, socialSettings) {
     const currentSetting = socialSettings.find(socialSetting => socialSetting.title === name)
     const subSettingPhrases = currentSetting.phrases.filter(phrase => phrase.tags[0] === id)
-    return subSettingPhrases.map(phrase => <Phrase categoryName={phrase} />
+    return subSettingPhrases.map(phrase => <Phrase categoryName={phrase}  phraseName={phrase.expression}  />
 )
 } 
 

--- a/src/Components/SubCategoriesPage/SubCategoriesPage.js
+++ b/src/Components/SubCategoriesPage/SubCategoriesPage.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { connect } from "react-redux"
+import { store } from '../../index'
+import useSubCategoriesPage from './useSubCategoriesPage';
+
+
+function SubCategoriesPage(props) {
+    const { name } = props
+    const { socialSettings } = props.AppState
+    const relatedPhrases = useSubCategoriesPage(name, socialSettings)
+    
+
+
+    return (
+        <section
+            className='sub-categories-container'
+            onClick={(e) => {
+            }}
+        >
+            {relatedPhrases && relatedPhrases}
+        </section>
+    )
+}
+
+const mapStateToProps = () => {
+    return store.getState()
+}
+export default connect(mapStateToProps)(SubCategoriesPage);

--- a/src/Components/SubCategoriesPage/SubCategoriesPage.js
+++ b/src/Components/SubCategoriesPage/SubCategoriesPage.js
@@ -13,7 +13,7 @@ function SubCategoriesPage(props) {
 
     return (
         <section
-            className='sub-categories-container'
+            className='phrase-page-container'
             onClick={(e) => {
             }}
         >

--- a/src/Components/SubCategoriesPage/useSubCategoriesPage.js
+++ b/src/Components/SubCategoriesPage/useSubCategoriesPage.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import SubCategory from '../SubCategory/subCategory'
+import { Link } from 'react-router-dom'
+
+
+function useSubCategoriesPage(name, socialSettings) {
+    console.log(name);
+    const relatedPhrases = socialSettings && socialSettings.find(socialSetting => socialSetting.title === name)
+
+
+    const removeUndefined = (relatedPhrases) => {
+        const minusUndefined = relatedPhrases.phrases.map(phrase => {
+            if (phrase.tags[0] === '') phrase.tags[0] = 'Common'
+            return phrase
+        })
+        return sortRelatedPhrases(minusUndefined)
+    }
+
+    const sortRelatedPhrases = (relatedPhrases) => {
+        const relatedPhrasesObj =  relatedPhrases.reduce((acc, phrase) => {
+            if (!acc[phrase.tags]) {
+                acc[phrase.tags] = []
+            }
+            acc[phrase.tags].push(phrase)
+            return acc
+        }, {})
+        return renderSubCategories(relatedPhrasesObj)
+    }
+
+    const renderSubCategories = (relatedPhrasesObj) => {
+        const relatedPhrasesKeys = Object.keys(relatedPhrasesObj)
+        return relatedPhrasesKeys.map(key => {
+            console.log(key);
+            return (
+            <Link
+                name={name}
+                key={key}
+                to={`/phrase-page/${ name }/${ key }`}
+                style={{ textDecoration: 'none', color: 'inherit' }}
+            >   
+                <SubCategory categoryName={key}  />
+            </Link>
+            )
+        })
+    }
+
+
+    return removeUndefined(relatedPhrases)
+}
+
+export default useSubCategoriesPage

--- a/src/Components/SubCategory/subCategory.js
+++ b/src/Components/SubCategory/subCategory.js
@@ -1,18 +1,23 @@
 import React from 'react'
-import './subCategory.css';
+import './subCategory.css'
+import { Link } from 'react-router-dom'
 // import BankImage from '../../Assets/SocialSettings/Bank.png'
 // import PartyImage from '../../Assets/SocialSettings/Party.png'
-import { Emoji } from '../Emoji/Emoji'
+import Emoji from '../Emoji/Emoji'
 // import "../Emoji/Emoji.css"
 
 
 function SubCategory(props) {
-  const { categoryName, img } = props
-  console.log(img)
+    const { categoryName, phrases} = props    
+
     return(
         <section className='sub-category-container'>
-        <Emoji className="sub-category-emoji"/>
-            <h4>{ categoryName }</h4>
+                <Emoji 
+                    className="sub-category-emoji"
+                    name={ categoryName }
+                    id={phrases}
+                />
+                <h4>{ categoryName }</h4>
         </section>
 
     )


### PR DESCRIPTION
## Pull request checklist
Please check if your PR fulfills the following requirements:
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe): 
## What is the current behavior?
- Previously a user could not click on the bank or party category and see their subcategories 
## What is the new behavior?
-  User can no click on the bank or party category and see the subcategories (Greetings, transactions) and by clicking on the subcategories they can see the phrases inside of each subcategory.
## Does this introduce a breaking change?
- [x] Yes
- [ ] No
Sound does not seem to be working.
## Other information

