### PR TITLE
Feature/add back button phrases

### DIFF
--- a/src/Components/PhrasesPage/PhrasePage.css
+++ b/src/Components/PhrasesPage/PhrasePage.css
@@ -52,5 +52,5 @@ p {
 .phrases-container {
   display: flex;
   flex-wrap: wrap;
-  /* justify-content: space-around; */
+  justify-content: space-evenly;
 }

--- a/src/Components/PhrasesPage/PhrasePage.css
+++ b/src/Components/PhrasesPage/PhrasePage.css
@@ -49,3 +49,8 @@ p {
   box-shadow: inset 4px 7px 13px 0px #000000c2,
     inset -4px -2px 13px 0px #000000c2, inset 0px 0px 13px 0px #000000c2;
 }
+.phrases-container {
+  display: flex;
+  flex-wrap: wrap;
+  /* justify-content: space-around; */
+}

--- a/src/Components/PhrasesPage/PhrasePage.js
+++ b/src/Components/PhrasesPage/PhrasePage.js
@@ -4,6 +4,8 @@ import { store } from '../../index'
 import './PhrasePage.css';
 import usePhrasePage from './usePhrasePage';
 import { Link } from 'react-router-dom'
+import Button from '../Button/Button'
+
 
 function PhrasePage(props) {
 
@@ -13,9 +15,19 @@ function PhrasePage(props) {
   
   return (
     <section 
-      className='phrase-page-container'
+      className='back-button-container'
     >   
-    {relatedPhrases}
+      <section className='sub-category-page-container'>
+      <Link
+        key={'Back'}
+        to={'/'}
+        style={{ textDecoration: 'none', color: 'inherit' }}
+      >
+        <Button name={'Back'} />
+      </Link>
+      </section>
+    <section className="phrases-container" >
+      {relatedPhrases}
       <section className='add-phrase-container'>
         <section className='add-phrase-button'>
           <Link
@@ -23,10 +35,11 @@ function PhrasePage(props) {
               id={'id'}
               to={`/addPhrase/${name}/${id}`}
               style={{ textDecoration: 'none', color: 'inherit' }}
-          ><section><span role='img' aria-label='add a phrase'>➕</span></section>
+              ><section><span role='img' aria-label='add a phrase'>➕</span></section>
           </Link>
         </section>
         <p>Add Phrase</p>
+        </section>
       </section>
     </section>
   )

--- a/src/Components/PhrasesPage/PhrasePage.js
+++ b/src/Components/PhrasesPage/PhrasePage.js
@@ -15,7 +15,7 @@ function PhrasePage(props) {
   
   return (
     <section 
-      className='back-button-container'
+      className='phrase-page-container'
     >   
       <section className='sub-category-page-container'>
       <Link

--- a/src/Components/PhrasesPage/PhrasePage.js
+++ b/src/Components/PhrasesPage/PhrasePage.js
@@ -20,7 +20,7 @@ function PhrasePage(props) {
       <section className='sub-category-page-container'>
       <Link
         key={'Back'}
-        to={'/'}
+        to={`/subCategories-page/${name}`}
         style={{ textDecoration: 'none', color: 'inherit' }}
       >
         <Button name={'Back'} />

--- a/src/Components/SubCategoriesPage/SubCategoriesPage.js
+++ b/src/Components/SubCategoriesPage/SubCategoriesPage.js
@@ -28,7 +28,6 @@ function SubCategoriesPage(props) {
           }}
         >
           {relatedPhrases && relatedPhrases}
-        </section>
         <section className='add-phrase-container'>
           <section className='add-phrase-button'>
             <Link
@@ -36,10 +35,11 @@ function SubCategoriesPage(props) {
               id={'id'}
               to={`/addSubcategoryForm/${name}`}
               style={{ textDecoration: 'none', color: 'inherit' }}
-            ><section><span role='img' aria-label='add a phrase'>➕</span></section>
+              ><section><span role='img' aria-label='add a phrase'>➕</span></section>
             </Link>
           </section>
           <p>Add A Subcategory</p>
+          </section>
         </section>
       </>
     )

--- a/src/Components/SubCategoriesPage/SubCategoriesPage.js
+++ b/src/Components/SubCategoriesPage/SubCategoriesPage.js
@@ -39,7 +39,7 @@ function SubCategoriesPage(props) {
             </Link>
           </section>
           <p>Add A Subcategory</p>
-          </section>
+              </section>
         </section>
       </>
     )

--- a/src/Components/SubCategoriesPage/SubCategoriesPage.js
+++ b/src/Components/SubCategoriesPage/SubCategoriesPage.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux"
 import { store } from '../../index'
 import useSubCategoriesPage from './useSubCategoriesPage';
 import Button from '../Button/Button'
+import '../PhrasesPage/PhrasePage.css'
 
 
 function SubCategoriesPage(props) {


### PR DESCRIPTION
## Pull request checklist
Please check if your PR fulfills the following requirements:
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures
## Pull request type
<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe): 
## What is the current behavior?
- Currently, there is no back button on the phrase page
## What is the new behavior?
- I added a back button to the phrases page so that the user can return to the subcategories page id they need to.
## Does this introduce a breaking change?
- [ ] Yes
- [x] No
## Other information
n/a
